### PR TITLE
Build 1.2 new changes

### DIFF
--- a/packages/contracts/src/Admin.sol
+++ b/packages/contracts/src/Admin.sol
@@ -8,7 +8,7 @@ import {IMembership} from "@aragon/osx-commons-contracts/src/plugin/extensions/m
 
 // solhint-disable-next-line max-line-length
 import {ProposalUpgradeable} from "@aragon/osx-commons-contracts/src/plugin/extensions/proposal/ProposalUpgradeable.sol";
-import {PluginCloneable} from "@aragon/osx-commons-contracts/src/plugin/PluginCloneable.sol";
+import {PluginUUPSUpgradeable} from "@aragon/osx-commons-contracts/src/plugin/PluginUUPSUpgradeable.sol";
 import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
 import {IProposal} from "@aragon/osx-commons-contracts/src/plugin/extensions/proposal/IProposal.sol";
 
@@ -17,7 +17,7 @@ import {IProposal} from "@aragon/osx-commons-contracts/src/plugin/extensions/pro
 /// @notice The admin governance plugin giving execution permission on the DAO to a single address.
 /// @dev v1.2 (Release 1, Build 2)
 /// @custom:security-contact sirt@aragon.org
-contract Admin is IMembership, PluginCloneable, ProposalUpgradeable {
+contract Admin is IMembership, PluginUUPSUpgradeable, ProposalUpgradeable {
     using SafeCastUpgradeable for uint256;
 
     /// @notice The [ERC-165](https://eips.ethereum.org/EIPS/eip-165) interface ID of the contract.
@@ -34,7 +34,7 @@ contract Admin is IMembership, PluginCloneable, ProposalUpgradeable {
     /// @param _dao The associated DAO.
     /// @dev This method is required to support [ERC-1167](https://eips.ethereum.org/EIPS/eip-1167).
     function initialize(IDAO _dao, TargetConfig calldata _targetConfig) external initializer {
-        __PluginCloneable_init(_dao);
+        __PluginUUPSUpgradeable_init(_dao);
 
         _setTargetConfig(_targetConfig);
 
@@ -46,7 +46,7 @@ contract Admin is IMembership, PluginCloneable, ProposalUpgradeable {
     /// @return Returns `true` if the interface is supported.
     function supportsInterface(
         bytes4 _interfaceId
-    ) public view override(PluginCloneable, ProposalUpgradeable) returns (bool) {
+    ) public view override(PluginUUPSUpgradeable, ProposalUpgradeable) returns (bool) {
         return
             _interfaceId == ADMIN_INTERFACE_ID ||
             _interfaceId == type(IMembership).interfaceId ||
@@ -141,5 +141,13 @@ contract Admin is IMembership, PluginCloneable, ProposalUpgradeable {
         );
 
         emit ProposalExecuted(proposalId);
+    }
+
+    /// @notice Internal method authorizing the upgrade of the contract via the [upgradeability mechanism for UUPS proxies](https://docs.openzeppelin.com/contracts/4.x/api/proxy#UUPSUpgradeable) (see [ERC-1822](https://eips.ethereum.org/EIPS/eip-1822)).
+    /// @dev The Upgradeability disabled.
+    function _authorizeUpgrade(
+        address
+    ) internal virtual override auth(UPGRADE_PLUGIN_PERMISSION_ID) {
+        revert NotAllowedOperation();
     }
 }

--- a/packages/contracts/src/Admin.sol
+++ b/packages/contracts/src/Admin.sol
@@ -8,7 +8,7 @@ import {IMembership} from "@aragon/osx-commons-contracts/src/plugin/extensions/m
 
 // solhint-disable-next-line max-line-length
 import {ProposalUpgradeable} from "@aragon/osx-commons-contracts/src/plugin/extensions/proposal/ProposalUpgradeable.sol";
-import {PluginUUPSUpgradeable} from "@aragon/osx-commons-contracts/src/plugin/PluginUUPSUpgradeable.sol";
+import {PluginCloneable} from "@aragon/osx-commons-contracts/src/plugin/PluginCloneable.sol";
 import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
 import {IProposal} from "@aragon/osx-commons-contracts/src/plugin/extensions/proposal/IProposal.sol";
 import {IExecutor, Action} from "@aragon/osx-commons-contracts/src/executors/IExecutor.sol";
@@ -18,7 +18,7 @@ import {IExecutor, Action} from "@aragon/osx-commons-contracts/src/executors/IEx
 /// @notice The admin governance plugin giving execution permission on the DAO to a single address.
 /// @dev v1.2 (Release 1, Build 2)
 /// @custom:security-contact sirt@aragon.org
-contract Admin is IMembership, PluginUUPSUpgradeable, ProposalUpgradeable {
+contract Admin is IMembership, PluginCloneable, ProposalUpgradeable {
     using SafeCastUpgradeable for uint256;
 
     /// @notice The [ERC-165](https://eips.ethereum.org/EIPS/eip-165) interface ID of the contract.
@@ -34,7 +34,7 @@ contract Admin is IMembership, PluginUUPSUpgradeable, ProposalUpgradeable {
     /// @param _dao The associated DAO.
     /// @dev This method is required to support [ERC-1167](https://eips.ethereum.org/EIPS/eip-1167).
     function initialize(IDAO _dao, TargetConfig calldata _targetConfig) external initializer {
-        __PluginUUPSUpgradeable_init(_dao);
+        __PluginCloneable_init(_dao);
 
         _setTargetConfig(_targetConfig);
 
@@ -46,7 +46,7 @@ contract Admin is IMembership, PluginUUPSUpgradeable, ProposalUpgradeable {
     /// @return Returns `true` if the interface is supported.
     function supportsInterface(
         bytes4 _interfaceId
-    ) public view override(PluginUUPSUpgradeable, ProposalUpgradeable) returns (bool) {
+    ) public view override(PluginCloneable, ProposalUpgradeable) returns (bool) {
         return
             _interfaceId == ADMIN_INTERFACE_ID ||
             _interfaceId == type(IMembership).interfaceId ||
@@ -148,13 +148,5 @@ contract Admin is IMembership, PluginUUPSUpgradeable, ProposalUpgradeable {
         );
 
         emit ProposalExecuted(proposalId);
-    }
-
-    /// @notice Internal method authorizing the upgrade of the contract via the [upgradeability mechanism for UUPS proxies](https://docs.openzeppelin.com/contracts/4.x/api/proxy#UUPSUpgradeable) (see [ERC-1822](https://eips.ethereum.org/EIPS/eip-1822)).
-    /// @dev The Upgradeability disabled.
-    function _authorizeUpgrade(
-        address
-    ) internal virtual override auth(UPGRADE_PLUGIN_PERMISSION_ID) {
-        revert NotAllowedOperation();
     }
 }

--- a/packages/contracts/src/Admin.sol
+++ b/packages/contracts/src/Admin.sol
@@ -102,6 +102,7 @@ contract Admin is IMembership, PluginUUPSUpgradeable, ProposalUpgradeable {
             allowFailureMap = abi.decode(_data, (uint256));
         }
 
+        // Uses public function for permission check.
         execute(_metadata, _actions, allowFailureMap);
     }
 

--- a/packages/contracts/src/Admin.sol
+++ b/packages/contracts/src/Admin.sol
@@ -11,7 +11,7 @@ import {ProposalUpgradeable} from "@aragon/osx-commons-contracts/src/plugin/exte
 import {PluginUUPSUpgradeable} from "@aragon/osx-commons-contracts/src/plugin/PluginUUPSUpgradeable.sol";
 import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
 import {IProposal} from "@aragon/osx-commons-contracts/src/plugin/extensions/proposal/IProposal.sol";
-import {IExecutor} from "@aragon/osx-commons-contracts/src/executors/IExecutor.sol";
+import {IExecutor, Action} from "@aragon/osx-commons-contracts/src/executors/IExecutor.sol";
 
 /// @title Admin
 /// @author Aragon X - 2022-2023
@@ -77,7 +77,7 @@ contract Admin is IMembership, PluginUUPSUpgradeable, ProposalUpgradeable {
     /// @param _metadata The metadata of the proposal.
     /// @return proposalId The ID of the proposal.
     function createProposalId(
-        IExecutor.Action[] calldata _actions,
+        Action[] calldata _actions,
         bytes memory _metadata
     ) public pure override returns (uint256) {
         return uint256(keccak256(abi.encode(_actions, _metadata)));
@@ -92,7 +92,7 @@ contract Admin is IMembership, PluginUUPSUpgradeable, ProposalUpgradeable {
     /// @inheritdoc IProposal
     function createProposal(
         bytes calldata _metadata,
-        IExecutor.Action[] calldata _actions,
+        Action[] calldata _actions,
         uint64,
         uint64,
         bytes memory _data
@@ -120,7 +120,7 @@ contract Admin is IMembership, PluginUUPSUpgradeable, ProposalUpgradeable {
     // of 0 requires every action to not revert.
     function execute(
         bytes calldata _metadata,
-        IExecutor.Action[] calldata _actions,
+        Action[] calldata _actions,
         uint256 _allowFailureMap
     ) public auth(EXECUTE_PROPOSAL_PERMISSION_ID) {
         uint64 currentTimestamp64 = block.timestamp.toUint64();

--- a/packages/contracts/src/Admin.sol
+++ b/packages/contracts/src/Admin.sol
@@ -11,6 +11,7 @@ import {ProposalUpgradeable} from "@aragon/osx-commons-contracts/src/plugin/exte
 import {PluginUUPSUpgradeable} from "@aragon/osx-commons-contracts/src/plugin/PluginUUPSUpgradeable.sol";
 import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
 import {IProposal} from "@aragon/osx-commons-contracts/src/plugin/extensions/proposal/IProposal.sol";
+import {IExecutor} from "@aragon/osx-commons-contracts/src/executors/IExecutor.sol";
 
 /// @title Admin
 /// @author Aragon X - 2022-2023
@@ -76,7 +77,7 @@ contract Admin is IMembership, PluginUUPSUpgradeable, ProposalUpgradeable {
     /// @param _metadata The metadata of the proposal.
     /// @return proposalId The ID of the proposal.
     function createProposalId(
-        IDAO.Action[] calldata _actions,
+        IExecutor.Action[] calldata _actions,
         bytes memory _metadata
     ) public pure override returns (uint256) {
         return uint256(keccak256(abi.encode(_actions, _metadata)));
@@ -91,7 +92,7 @@ contract Admin is IMembership, PluginUUPSUpgradeable, ProposalUpgradeable {
     /// @inheritdoc IProposal
     function createProposal(
         bytes calldata _metadata,
-        IDAO.Action[] calldata _actions,
+        IExecutor.Action[] calldata _actions,
         uint64,
         uint64,
         bytes memory _data
@@ -119,7 +120,7 @@ contract Admin is IMembership, PluginUUPSUpgradeable, ProposalUpgradeable {
     // of 0 requires every action to not revert.
     function execute(
         bytes calldata _metadata,
-        IDAO.Action[] calldata _actions,
+        IExecutor.Action[] calldata _actions,
         uint256 _allowFailureMap
     ) public auth(EXECUTE_PROPOSAL_PERMISSION_ID) {
         uint64 currentTimestamp64 = block.timestamp.toUint64();

--- a/packages/contracts/src/Admin.sol
+++ b/packages/contracts/src/Admin.sol
@@ -86,7 +86,7 @@ contract Admin is IMembership, PluginCloneable, ProposalUpgradeable {
     }
 
     /// @inheritdoc IProposal
-    function canExecute(uint256) public view virtual override returns (bool) {
+    function hasSucceeded(uint256) public view virtual override returns (bool) {
         return true;
     }
 

--- a/packages/contracts/src/AdminSetup.sol
+++ b/packages/contracts/src/AdminSetup.sol
@@ -19,9 +19,12 @@ import {Admin} from "./Admin.sol";
 contract AdminSetup is PluginSetup {
     using ProxyLib for address;
 
-    // TODO This permission identifier has to be moved inside `PermissionLib` as per task OS-954.
     /// @notice The ID of the permission required to call the `execute` function.
     bytes32 internal constant EXECUTE_PERMISSION_ID = keccak256("EXECUTE_PERMISSION");
+
+    /// @notice The ID of the permission required to call the `executeProposal` function.
+    bytes32 public constant EXECUTE_PROPOSAL_PERMISSION_ID =
+        keccak256("EXECUTE_PROPOSAL_PERMISSION");
 
     /// @notice Thrown if the admin address is zero.
     /// @param admin The admin address.
@@ -59,7 +62,7 @@ contract AdminSetup is PluginSetup {
             where: plugin,
             who: admin,
             condition: PermissionLib.NO_CONDITION,
-            permissionId: Admin(plugin).EXECUTE_PROPOSAL_PERMISSION_ID()
+            permissionId: EXECUTE_PROPOSAL_PERMISSION_ID
         });
 
         // Grant `EXECUTE_PERMISSION` on the DAO to the plugin.

--- a/packages/contracts/src/AdminSetup.sol
+++ b/packages/contracts/src/AdminSetup.sol
@@ -7,7 +7,7 @@ import {PluginSetup} from "@aragon/osx-commons-contracts/src/plugin/setup/Plugin
 import {PermissionLib} from "@aragon/osx-commons-contracts/src/permission/PermissionLib.sol";
 import {ProxyLib} from "@aragon/osx-commons-contracts/src/utils/deployment/ProxyLib.sol";
 import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
-import {PluginCloneable} from "@aragon/osx-commons-contracts/src/plugin/PluginCloneable.sol";
+import {PluginUUPSUpgradeable} from "@aragon/osx-commons-contracts/src/plugin/PluginUUPSUpgradeable.sol";
 
 import {Admin} from "./Admin.sol";
 
@@ -36,9 +36,9 @@ contract AdminSetup is PluginSetup {
         bytes calldata _data
     ) external returns (address plugin, PreparedSetupData memory preparedSetupData) {
         // Decode `_data` to extract the params needed for cloning and initializing the `Admin` plugin.
-        (address admin, PluginCloneable.TargetConfig memory targetConfig) = abi.decode(
+        (address admin, PluginUUPSUpgradeable.TargetConfig memory targetConfig) = abi.decode(
             _data,
-            (address, PluginCloneable.TargetConfig)
+            (address, PluginUUPSUpgradeable.TargetConfig)
         );
 
         if (admin == address(0)) {
@@ -47,7 +47,7 @@ contract AdminSetup is PluginSetup {
 
         // Clone and initialize the plugin contract.
         bytes memory initData = abi.encodeCall(Admin.initialize, (IDAO(_dao), targetConfig));
-        plugin = IMPLEMENTATION.deployMinimalProxy(initData);
+        plugin = IMPLEMENTATION.deployUUPSProxy(initData);
 
         // Prepare permissions
         PermissionLib.MultiTargetPermission[]

--- a/packages/contracts/src/AdminSetup.sol
+++ b/packages/contracts/src/AdminSetup.sol
@@ -7,6 +7,7 @@ import {PluginSetup} from "@aragon/osx-commons-contracts/src/plugin/setup/Plugin
 import {PermissionLib} from "@aragon/osx-commons-contracts/src/permission/PermissionLib.sol";
 import {ProxyLib} from "@aragon/osx-commons-contracts/src/utils/deployment/ProxyLib.sol";
 import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
+import {PluginCloneable} from "@aragon/osx-commons-contracts/src/plugin/PluginCloneable.sol";
 
 import {Admin} from "./Admin.sol";
 
@@ -35,14 +36,17 @@ contract AdminSetup is PluginSetup {
         bytes calldata _data
     ) external returns (address plugin, PreparedSetupData memory preparedSetupData) {
         // Decode `_data` to extract the params needed for cloning and initializing the `Admin` plugin.
-        address admin = abi.decode(_data, (address));
+        (address admin, PluginCloneable.TargetConfig memory targetConfig) = abi.decode(
+            _data,
+            (address, PluginCloneable.TargetConfig)
+        );
 
         if (admin == address(0)) {
             revert AdminAddressInvalid({admin: admin});
         }
 
         // Clone and initialize the plugin contract.
-        bytes memory initData = abi.encodeCall(Admin.initialize, (IDAO(_dao)));
+        bytes memory initData = abi.encodeCall(Admin.initialize, (IDAO(_dao), targetConfig));
         plugin = IMPLEMENTATION.deployMinimalProxy(initData);
 
         // Prepare permissions

--- a/packages/contracts/src/AdminSetup.sol
+++ b/packages/contracts/src/AdminSetup.sol
@@ -7,7 +7,7 @@ import {PluginSetup} from "@aragon/osx-commons-contracts/src/plugin/setup/Plugin
 import {PermissionLib} from "@aragon/osx-commons-contracts/src/permission/PermissionLib.sol";
 import {ProxyLib} from "@aragon/osx-commons-contracts/src/utils/deployment/ProxyLib.sol";
 import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
-import {PluginUUPSUpgradeable} from "@aragon/osx-commons-contracts/src/plugin/PluginUUPSUpgradeable.sol";
+import {PluginCloneable} from "@aragon/osx-commons-contracts/src/plugin/PluginCloneable.sol";
 
 import {Admin} from "./Admin.sol";
 
@@ -36,9 +36,9 @@ contract AdminSetup is PluginSetup {
         bytes calldata _data
     ) external returns (address plugin, PreparedSetupData memory preparedSetupData) {
         // Decode `_data` to extract the params needed for cloning and initializing the `Admin` plugin.
-        (address admin, PluginUUPSUpgradeable.TargetConfig memory targetConfig) = abi.decode(
+        (address admin, PluginCloneable.TargetConfig memory targetConfig) = abi.decode(
             _data,
-            (address, PluginUUPSUpgradeable.TargetConfig)
+            (address, PluginCloneable.TargetConfig)
         );
 
         if (admin == address(0)) {
@@ -47,7 +47,7 @@ contract AdminSetup is PluginSetup {
 
         // Clone and initialize the plugin contract.
         bytes memory initData = abi.encodeCall(Admin.initialize, (IDAO(_dao), targetConfig));
-        plugin = IMPLEMENTATION.deployUUPSProxy(initData);
+        plugin = IMPLEMENTATION.deployMinimalProxy(initData);
 
         // Prepare permissions
         PermissionLib.MultiTargetPermission[]

--- a/packages/contracts/src/build-metadata.json
+++ b/packages/contracts/src/build-metadata.json
@@ -10,6 +10,26 @@
           "name": "admin",
           "type": "address",
           "description": "The address of the admin account receiving the `EXECUTE_PERMISSION_ID` permission."
+        },
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "target",
+              "type": "address",
+              "description": "The target contract to which actions will be forwarded to for execution."
+            },
+            {
+              "internalType": "uint8",
+              "name": "operation",
+              "type": "uint8",
+              "description": "The operation type(either `call` or `delegatecall`) that will be used for execution forwarding."
+            }
+          ],
+          "internalType": "struct TokenVoting.TargetConfig",
+          "name": "TargetConfig",
+          "type": "tuple",
+          "description": "The initial target config"
         }
       ]
     },

--- a/packages/contracts/src/mocks/CustomExecutorMock.sol
+++ b/packages/contracts/src/mocks/CustomExecutorMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.8;
 
-import {IExecutor} from "@aragon/osx-commons-contracts/src/executors/IExecutor.sol";
+import {IExecutor, Action} from "@aragon/osx-commons-contracts/src/executors/IExecutor.sol";
 
 /// @dev DO NOT USE IN PRODUCTION!
 contract CustomExecutorMock {
@@ -12,7 +12,7 @@ contract CustomExecutorMock {
 
     function execute(
         bytes32 callId,
-        IExecutor.Action[] memory,
+        Action[] memory,
         uint256
     ) external returns (bytes[] memory execResults, uint256 failureMap) {
         (execResults, failureMap);

--- a/packages/contracts/src/mocks/CustomExecutorMock.sol
+++ b/packages/contracts/src/mocks/CustomExecutorMock.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+pragma solidity ^0.8.8;
+
+import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
+
+/// @dev DO NOT USE IN PRODUCTION!
+contract CustomExecutorMock {
+    error FailedCustom();
+
+    event ExecutedCustom();
+
+    function execute(
+        bytes32 callId,
+        IDAO.Action[] memory,
+        uint256
+    ) external returns (bytes[] memory execResults, uint256 failureMap) {
+        (execResults, failureMap);
+
+        if (callId == bytes32(0)) {
+            revert FailedCustom();
+        } else {
+            emit ExecutedCustom();
+        }
+    }
+}

--- a/packages/contracts/src/mocks/CustomExecutorMock.sol
+++ b/packages/contracts/src/mocks/CustomExecutorMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.8;
 
-import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
+import {IExecutor} from "@aragon/osx-commons-contracts/src/executors/IExecutor.sol";
 
 /// @dev DO NOT USE IN PRODUCTION!
 contract CustomExecutorMock {
@@ -12,7 +12,7 @@ contract CustomExecutorMock {
 
     function execute(
         bytes32 callId,
-        IDAO.Action[] memory,
+        IExecutor.Action[] memory,
         uint256
     ) external returns (bytes[] memory execResults, uint256 failureMap) {
         (execResults, failureMap);

--- a/packages/contracts/test/10_unit-testing/11_plugin.ts
+++ b/packages/contracts/test/10_unit-testing/11_plugin.ts
@@ -123,7 +123,7 @@ describe(PLUGIN_CONTRACT_NAME, function () {
   });
 
   describe('execute proposal: ', async () => {
-    it('reverts when calling `executeProposal()` if `EXECUTE_PROPOSAL_PERMISSION_ID` is not granted to the admin address', async () => {
+    it('reverts when calling `execute()` if `EXECUTE_PROPOSAL_PERMISSION_ID` is not granted to the admin address', async () => {
       const {
         alice,
         initializedPlugin: plugin,
@@ -142,9 +142,9 @@ describe(PLUGIN_CONTRACT_NAME, function () {
         )
       ).to.be.false;
 
-      // Expect Alice's `executeProposal` call to be reverted because she hasn't `EXECUTE_PROPOSAL_PERMISSION_ID` on the Admin plugin
+      // Expect Alice's `execute` call to be reverted because she hasn't `EXECUTE_PROPOSAL_PERMISSION_ID` on the Admin plugin
       await expect(
-        plugin.connect(alice).executeProposal(dummyMetadata, dummyActions, 0)
+        plugin.connect(alice).execute(dummyMetadata, dummyActions, 0)
       )
         .to.be.revertedWithCustomError(plugin, 'DaoUnauthorized')
         .withArgs(
@@ -155,7 +155,7 @@ describe(PLUGIN_CONTRACT_NAME, function () {
         );
     });
 
-    it('reverts when calling `executeProposal()` if the `EXECUTE_PERMISSION_ID` on the DAO is not granted to the plugin address', async () => {
+    it('reverts when calling `execute()` if the `EXECUTE_PERMISSION_ID` on the DAO is not granted to the plugin address', async () => {
       const {
         alice,
         initializedPlugin: plugin,
@@ -181,9 +181,9 @@ describe(PLUGIN_CONTRACT_NAME, function () {
         )
       ).to.be.false;
 
-      // Expect Alice's  the `executeProposal` call to be reverted because the Admin plugin hasn't `EXECUTE_PERMISSION_ID` on the DAO
+      // Expect Alice's  the `execute` call to be reverted because the Admin plugin hasn't `EXECUTE_PERMISSION_ID` on the DAO
       await expect(
-        plugin.connect(alice).executeProposal(dummyMetadata, dummyActions, 0)
+        plugin.connect(alice).execute(dummyMetadata, dummyActions, 0)
       )
         .to.be.revertedWithCustomError(dao, 'Unauthorized')
         .withArgs(
@@ -224,7 +224,7 @@ describe(PLUGIN_CONTRACT_NAME, function () {
 
       const tx = await plugin
         .connect(alice)
-        .executeProposal(dummyMetadata, dummyActions, allowFailureMap);
+        .execute(dummyMetadata, dummyActions, allowFailureMap);
 
       const eventName = plugin.interface.getEvent('ProposalCreated').name;
       await expect(tx).to.emit(plugin, eventName);
@@ -267,7 +267,7 @@ describe(PLUGIN_CONTRACT_NAME, function () {
       );
 
       await expect(
-        plugin.connect(alice).executeProposal(dummyMetadata, dummyActions, 0)
+        plugin.connect(alice).execute(dummyMetadata, dummyActions, 0)
       )
         .to.emit(plugin, plugin.interface.getEvent('ProposalExecuted').name)
         .withArgs(currentExpectedProposalId);
@@ -306,7 +306,7 @@ describe(PLUGIN_CONTRACT_NAME, function () {
 
         const tx = await newPlugin
           .connect(alice)
-          .executeProposal(dummyMetadata, dummyActions, allowFailureMap);
+          .execute(dummyMetadata, dummyActions, allowFailureMap);
 
         const event = findEventTopicLog<DAOEvents.ExecutedEvent>(
           await tx.wait(),
@@ -334,7 +334,7 @@ describe(PLUGIN_CONTRACT_NAME, function () {
 
         const tx = await newPlugin
           .connect(alice)
-          .executeProposal(newMetadata, dummyActions, 0);
+          .execute(newMetadata, dummyActions, 0);
 
         const event = findEventTopicLog<DAOEvents.ExecutedEvent>(
           await tx.wait(),

--- a/packages/contracts/test/10_unit-testing/11_plugin.ts
+++ b/packages/contracts/test/10_unit-testing/11_plugin.ts
@@ -146,7 +146,7 @@ describe(PLUGIN_CONTRACT_NAME, function () {
 
       // Expect Alice's `execute` call to be reverted because she hasn't `EXECUTE_PROPOSAL_PERMISSION_ID` on the Admin plugin
       await expect(
-        plugin.connect(alice).execute(dummyMetadata, dummyActions, 0)
+        plugin.connect(alice).executeProposal(dummyMetadata, dummyActions, 0)
       )
         .to.be.revertedWithCustomError(plugin, 'DaoUnauthorized')
         .withArgs(
@@ -185,7 +185,7 @@ describe(PLUGIN_CONTRACT_NAME, function () {
 
       // Expect Alice's  the `execute` call to be reverted because the Admin plugin hasn't `EXECUTE_PERMISSION_ID` on the DAO
       await expect(
-        plugin.connect(alice).execute(dummyMetadata, dummyActions, 0)
+        plugin.connect(alice).executeProposal(dummyMetadata, dummyActions, 0)
       )
         .to.be.revertedWithCustomError(dao, 'Unauthorized')
         .withArgs(
@@ -226,7 +226,7 @@ describe(PLUGIN_CONTRACT_NAME, function () {
 
       const tx = await plugin
         .connect(alice)
-        .execute(dummyMetadata, dummyActions, allowFailureMap);
+        .executeProposal(dummyMetadata, dummyActions, allowFailureMap);
 
       const eventName = plugin.interface.getEvent('ProposalCreated').name;
       await expect(tx).to.emit(plugin, eventName);
@@ -269,7 +269,7 @@ describe(PLUGIN_CONTRACT_NAME, function () {
       );
 
       await expect(
-        plugin.connect(alice).execute(dummyMetadata, dummyActions, 0)
+        plugin.connect(alice).executeProposal(dummyMetadata, dummyActions, 0)
       )
         .to.emit(plugin, plugin.interface.getEvent('ProposalExecuted').name)
         .withArgs(currentExpectedProposalId);
@@ -308,7 +308,7 @@ describe(PLUGIN_CONTRACT_NAME, function () {
 
         const tx = await newPlugin
           .connect(alice)
-          .execute(dummyMetadata, dummyActions, allowFailureMap);
+          .executeProposal(dummyMetadata, dummyActions, allowFailureMap);
 
         const event = findEventTopicLog<DAOEvents.ExecutedEvent>(
           await tx.wait(),
@@ -336,7 +336,7 @@ describe(PLUGIN_CONTRACT_NAME, function () {
 
         const tx = await newPlugin
           .connect(alice)
-          .execute(newMetadata, dummyActions, 0);
+          .executeProposal(newMetadata, dummyActions, 0);
 
         const event = findEventTopicLog<DAOEvents.ExecutedEvent>(
           await tx.wait(),
@@ -420,7 +420,7 @@ describe(PLUGIN_CONTRACT_NAME, function () {
       );
 
       await expect(
-        plugin.connect(alice).execute(dummyMetadata, dummyActions, 1)
+        plugin.connect(alice).executeProposal(dummyMetadata, dummyActions, 1)
       )
         .to.emit(pluginMerged, 'ExecutedCustom')
         .to.emit(pluginMerged, 'ProposalExecuted');

--- a/packages/contracts/test/20_integration-testing/22_setup-processing.ts
+++ b/packages/contracts/test/20_integration-testing/22_setup-processing.ts
@@ -1,6 +1,7 @@
 import {METADATA, VERSION} from '../../plugin-settings';
 import {AdminSetup, AdminSetup__factory, Admin__factory} from '../../typechain';
 import {getProductionNetworkName, findPluginRepo} from '../../utils/helpers';
+import {Operation, TargetConfig} from '../admin-constants';
 import {createDaoProxy, installPLugin, uninstallPLugin} from './test-helpers';
 import {
   getLatestNetworkDeployment,
@@ -28,9 +29,8 @@ const productionNetworkName = getProductionNetworkName(env);
 
 describe(`PluginSetup processing on network '${productionNetworkName}'`, function () {
   it('installs & uninstalls the current build', async () => {
-    const {alice, deployer, psp, dao, pluginSetupRef} = await loadFixture(
-      fixture
-    );
+    const {alice, deployer, psp, dao, pluginSetupRef, targetConfig} =
+      await loadFixture(fixture);
 
     // Grant deployer all required permissions
     await dao
@@ -61,7 +61,7 @@ describe(`PluginSetup processing on network '${productionNetworkName}'`, functio
         getNamedTypesFromMetadata(
           METADATA.build.pluginSetup.prepareInstallation.inputs
         ),
-        [alice.address]
+        [alice.address, targetConfig]
       )
     );
 
@@ -100,6 +100,7 @@ type FixtureResult = {
   pluginRepo: PluginRepo;
   pluginSetup: AdminSetup;
   pluginSetupRef: PluginSetupProcessorStructs.PluginSetupRefStruct;
+  targetConfig: TargetConfig;
 };
 
 async function fixture(): Promise<FixtureResult> {
@@ -138,6 +139,11 @@ async function fixture(): Promise<FixtureResult> {
     deployer
   );
 
+  const targetConfig: TargetConfig = {
+    operation: Operation.call,
+    target: dao.address,
+  };
+
   const pluginSetupRef = {
     versionTag: {
       release: VERSION.release,
@@ -155,5 +161,6 @@ async function fixture(): Promise<FixtureResult> {
     pluginRepo,
     pluginSetup,
     pluginSetupRef,
+    targetConfig,
   };
 }

--- a/packages/contracts/test/admin-constants.ts
+++ b/packages/contracts/test/admin-constants.ts
@@ -1,8 +1,7 @@
 import {ethers} from 'hardhat';
 
 export const ADMIN_INTERFACE = new ethers.utils.Interface([
-  'function initialize(address,tuple(address,uint8))',
-  'function execute(bytes,tuple(address,uint256,bytes)[],uint256)',
+  'function executeProposal(bytes,tuple(address,uint256,bytes)[],uint256)',
 ]);
 
 // Permissions

--- a/packages/contracts/test/admin-constants.ts
+++ b/packages/contracts/test/admin-constants.ts
@@ -10,6 +10,10 @@ export const EXECUTE_PROPOSAL_PERMISSION_ID = ethers.utils.id(
   'EXECUTE_PROPOSAL_PERMISSION'
 );
 
+export const SET_TARGET_CONFIG_PERMISSION_ID = ethers.utils.id(
+  'SET_TARGET_CONFIG_PERMISSION'
+);
+
 export enum Operation {
   call,
   delegatecall,

--- a/packages/contracts/test/admin-constants.ts
+++ b/packages/contracts/test/admin-constants.ts
@@ -1,7 +1,7 @@
 import {ethers} from 'hardhat';
 
 export const ADMIN_INTERFACE = new ethers.utils.Interface([
-  'function initialize(address)',
+  'function initialize(address,tuple(address,uint8))',
   'function executeProposal(bytes,tuple(address,uint256,bytes)[],uint256)',
 ]);
 
@@ -9,3 +9,13 @@ export const ADMIN_INTERFACE = new ethers.utils.Interface([
 export const EXECUTE_PROPOSAL_PERMISSION_ID = ethers.utils.id(
   'EXECUTE_PROPOSAL_PERMISSION'
 );
+
+export enum Operation {
+  call,
+  delegatecall,
+}
+
+export type TargetConfig = {
+  target: string;
+  operation: number;
+};

--- a/packages/contracts/test/admin-constants.ts
+++ b/packages/contracts/test/admin-constants.ts
@@ -2,7 +2,7 @@ import {ethers} from 'hardhat';
 
 export const ADMIN_INTERFACE = new ethers.utils.Interface([
   'function initialize(address,tuple(address,uint8))',
-  'function executeProposal(bytes,tuple(address,uint256,bytes)[],uint256)',
+  'function execute(bytes,tuple(address,uint256,bytes)[],uint256)',
 ]);
 
 // Permissions


### PR DESCRIPTION
The PR introduces the several changes:

* `ADMIN_INTERFACE_ID` changed as it no longer includes the `initialize`'s selector.
* Adheres to the new changes brought by `osx-commons`'s IProposal.
* Adheres to the new changes brought by `PluginCloneable` - i.e allowing targets to be set with either `call` or `delegatecall` operation types.
* Note that plugin setup at the time of installation doesn't grant `SET_TARGET_CONFIG_PERMISSION_ID` to the dao to reduce gas costs. Most of the time, admin needs its target to be `dao` and stay that way.